### PR TITLE
Add mock data script and driver name field

### DIFF
--- a/LPR_TH/app.py
+++ b/LPR_TH/app.py
@@ -320,16 +320,22 @@ def add_vehicle():
     data = request.get_json() or {}
     plate = data.get('plate')
     province = data.get('province')
+    driver_name = data.get('driver_name')
     if not plate:
         return jsonify({'error': 'plate required'}), 400
-    register_vehicle(db_conn, plate, province)
+    register_vehicle(db_conn, plate, province, driver_name)
     return jsonify({'status': 'registered'})
 
 
 @app.route('/vehicles')
 def get_vehicles():
     vehicles = [
-        {'plate': v[0], 'province': v[1]} for v in list_vehicles(db_conn)
+        {
+            'plate': v[0],
+            'province': v[1],
+            'driver_name': v[2],
+        }
+        for v in list_vehicles(db_conn)
     ]
     return jsonify(vehicles)
 

--- a/LPR_TH/function/database.py
+++ b/LPR_TH/function/database.py
@@ -10,7 +10,8 @@ def init_db(db_path=DB_PATH):
         CREATE TABLE IF NOT EXISTS registered_vehicles (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             plate TEXT NOT NULL,
-            province TEXT
+            province TEXT,
+            driver_name TEXT
         )
     ''')
     cursor.execute('''
@@ -26,15 +27,18 @@ def init_db(db_path=DB_PATH):
     conn.commit()
     return conn
 
-def register_vehicle(conn, plate, province=None):
+def register_vehicle(conn, plate, province=None, driver_name=None):
     cursor = conn.cursor()
-    cursor.execute('INSERT INTO registered_vehicles (plate, province) VALUES (?, ?)', (plate, province))
+    cursor.execute(
+        'INSERT INTO registered_vehicles (plate, province, driver_name) VALUES (?, ?, ?)',
+        (plate, province, driver_name)
+    )
     conn.commit()
 
 
 def list_vehicles(conn):
     cursor = conn.cursor()
-    cursor.execute('SELECT plate, province FROM registered_vehicles')
+    cursor.execute('SELECT plate, province, driver_name FROM registered_vehicles')
     return cursor.fetchall()
 
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,21 @@ https://github.com/ultralytics/ultralytics
 The application now uses a SQLite database (`vehicle.db`) to store registered
 vehicles and detection logs.  Routes were added to manage this data:
 
-- `POST /register_vehicle` – register a new plate in the database. JSON body
-  should contain `plate` and optional `province`.
+ - `POST /register_vehicle` – register a new plate in the database. JSON body
+   should contain `plate`, optional `province`, and optional `driver_name`.
 - `GET /vehicles` – list all registered vehicles.
 - `GET /detections` – retrieve detection history from the database.
 
 Detected plates are automatically checked against registered records and
 logged with the result.
+
+### Populating mock data
+
+To quickly create sample vehicles with driver names run:
+
+```bash
+python scripts/populate_mock_data.py
+```
+
+This will insert 100 random license plates with mock driver names into
+`vehicle.db`.

--- a/scripts/populate_mock_data.py
+++ b/scripts/populate_mock_data.py
@@ -1,0 +1,27 @@
+import random
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from LPR_TH.function.database import init_db, register_vehicle
+
+# Connect to database (creates if not exists)
+conn = init_db()
+
+thai_letters = [
+    'ก','ข','ค','ง','จ','ฉ','ช','ซ','ญ','ด','ต','ถ','ท','ธ','น','บ','ป','ผ','พ','ฟ','ม','ย','ร','ล','ว','ศ','ส','ห','อ','ฮ'
+]
+
+provinces = ['กรุงเทพมหานคร', 'ชลบุรี', 'เชียงใหม่', 'นครราชสีมา', 'ภูเก็ต']
+
+for i in range(100):
+    prefix = random.choice(thai_letters) + random.choice(thai_letters)
+    number = 1000 + i
+    plate = f"{prefix}{number}"
+    driver_name = f"คนขับ{i+1}"
+    province = random.choice(provinces)
+    register_vehicle(conn, plate, province, driver_name)
+
+print("Inserted 100 mock vehicle records.")


### PR DESCRIPTION
## Summary
- add `driver_name` column to registered vehicles
- expose driver names via `/register_vehicle` and `/vehicles`
- document `driver_name` usage in README
- add script to populate database with 100 mock records

## Testing
- `python -m py_compile LPR_TH/app.py LPR_TH/function/database.py scripts/populate_mock_data.py`
- `python scripts/populate_mock_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6841033a1e788324b09b0a288e5bc424